### PR TITLE
updates to uni1042 and uni1048

### DIFF
--- a/sources/NotoSansTaiLe.glyphs
+++ b/sources/NotoSansTaiLe.glyphs
@@ -1,5 +1,8 @@
 {
-.appVersion = "3109";
+.appVersion = "3316";
+DisplayStrings = (
+"/uni1040/uni1041/uni1042/uni1043/uni1044/uni1045/uni1046/uni1047/uni1048/uni1049 \012\012"
+);
 classes = (
 {
 code = "uni1963 uni1964 uni1965 uni1966 uni196A uni196B";
@@ -117,6 +120,10 @@ name = "Don't use Production Names";
 value = 1;
 },
 {
+name = "Use Typo Metrics";
+value = 1;
+},
+{
 name = description;
 value = "Designed by Monotype design team.";
 },
@@ -129,20 +136,16 @@ name = licenseURL;
 value = "https://scripts.sil.org/OFL";
 },
 {
-name = vendorID;
-value = GOOG;
-},
-{
 name = trademark;
 value = "Noto is a trademark of Google Inc.";
 },
 {
-name = versionString;
-value = "Version 2.002";
+name = vendorID;
+value = GOOG;
 },
 {
-name = "Use Typo Metrics";
-value = 1;
+name = versionString;
+value = "Version 2.002";
 }
 );
 date = "2017-05-04 18:53:13 +0000";
@@ -679,13 +682,19 @@ unicode = 1954;
 },
 {
 glyphname = uni1955;
-lastChange = "2017-09-08 15:50:39 +0000";
+lastChange = "2024-08-09 11:04:53 +0000";
 layers = (
 {
 anchors = (
 {
 name = Anchor2;
 position = "{63, 0}";
+}
+);
+guideLines = (
+{
+angle = 26.5651;
+position = "{278, 192}";
 }
 );
 layerId = UUID0;
@@ -1816,13 +1825,18 @@ unicode = 1962;
 },
 {
 glyphname = uni1963;
-lastChange = "2017-09-08 15:50:39 +0000";
+lastChange = "2024-09-05 16:28:21 +0000";
 layers = (
 {
 anchors = (
 {
 name = Anchor2;
 position = "{131, 0}";
+}
+);
+guideLines = (
+{
+position = "{121, 894}";
 }
 );
 layerId = UUID0;
@@ -3034,8 +3048,9 @@ width = 563;
 unicode = 1041;
 },
 {
+color = 4;
 glyphname = uni1042;
-lastChange = "2017-09-08 15:50:39 +0000";
+lastChange = "2024-09-05 16:51:23 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -3043,37 +3058,39 @@ paths = (
 {
 closed = 1;
 nodes = (
-"448 -293 OFFCURVE",
-"550 -162 OFFCURVE",
-"550 62 CURVE SMOOTH",
-"550 209 OFFCURVE",
-"547 413 OFFCURVE",
-"540 546 CURVE",
-"454 536 LINE",
-"463 406 OFFCURVE",
-"464 182 OFFCURVE",
-"464 55 CURVE SMOOTH",
-"464 -168 OFFCURVE",
-"390 -237 OFFCURVE",
-"272 -237 CURVE SMOOTH",
-"167 -237 OFFCURVE",
-"102 -145 OFFCURVE",
-"83 -88 CURVE",
-"4 -123 LINE",
-"52 -213 OFFCURVE",
-"145 -293 OFFCURVE",
-"257 -293 CURVE SMOOTH"
+"245 -293 OFFCURVE",
+"291 -248 OFFCURVE",
+"291 -138 CURVE SMOOTH",
+"291 353 LINE SMOOTH",
+"291 419 OFFCURVE",
+"299 499 OFFCURVE",
+"311 531 CURVE",
+"235 546 LINE",
+"215 501 OFFCURVE",
+"205 407 OFFCURVE",
+"205 342 CURVE SMOOTH",
+"205 -154 LINE SMOOTH",
+"205 -216 OFFCURVE",
+"175 -237 OFFCURVE",
+"92 -237 CURVE SMOOTH",
+"20 -237 OFFCURVE",
+"-54 -218 OFFCURVE",
+"-75 -210 CURVE",
+"-75 -264 LINE",
+"-58 -271 OFFCURVE",
+"31 -293 OFFCURVE",
+"118 -293 CURVE SMOOTH"
 );
 }
 );
-width = 599;
+width = 363;
 }
 );
 unicode = 1042;
 },
 {
 glyphname = uni1043;
-lastChange = "2017-09-08 15:50:39 +0000";
+lastChange = "2024-08-09 11:40:02 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -3253,7 +3270,7 @@ unicode = 1045;
 },
 {
 glyphname = uni1046;
-lastChange = "2017-09-08 15:50:39 +0000";
+lastChange = "2024-09-05 16:29:13 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -3390,57 +3407,66 @@ width = 629;
 unicode = 1047;
 },
 {
+color = 4;
 glyphname = uni1048;
-lastChange = "2017-09-08 15:50:39 +0000";
+lastChange = "2024-09-05 16:50:57 +0000";
 layers = (
 {
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"598 63 LINE",
+"380 67 OFFCURVE",
+"374 356 OFFCURVE",
+"366 556 CURVE",
+"280 522 LINE",
+"271 463 OFFCURVE",
+"252 77 OFFCURVE",
+"29 65 CURVE",
+"11 -3 LINE",
+"215 1 OFFCURVE",
+"281 176 OFFCURVE",
+"311 365 CURVE",
+"336 127 OFFCURVE",
+"401 0 OFFCURVE",
+"569 -9 CURVE"
+);
+}
+);
+};
 layerId = UUID0;
 paths = (
 {
 closed = 1;
 nodes = (
-"289 50 OFFCURVE",
-"346 147 OFFCURVE",
-"346 247 CURVE SMOOTH",
-"346 329 OFFCURVE",
-"291 438 OFFCURVE",
-"218 492 CURVE",
-"170 463 LINE",
-"221 417 OFFCURVE",
-"260 352 OFFCURVE",
-"260 233 CURVE SMOOTH",
-"260 170 OFFCURVE",
-"244 108 OFFCURVE",
-"211 63 CURVE",
-"170 89 OFFCURVE",
-"130 169 OFFCURVE",
-"130 283 CURVE SMOOTH",
-"130 394 OFFCURVE",
-"198 490 OFFCURVE",
-"318 490 CURVE SMOOTH",
-"440 490 OFFCURVE",
-"529 395 OFFCURVE",
-"529 252 CURVE SMOOTH",
-"529 153 OFFCURVE",
-"476 69 OFFCURVE",
-"410 34 CURVE",
-"434 -10 LINE",
-"538 42 OFFCURVE",
-"615 152 OFFCURVE",
-"615 269 CURVE SMOOTH",
-"615 396 OFFCURVE",
-"520 546 OFFCURVE",
-"332 546 CURVE SMOOTH",
-"146 546 OFFCURVE",
-"44 400 OFFCURVE",
-"44 264 CURVE SMOOTH",
-"44 155 OFFCURVE",
-"107 28 OFFCURVE",
-"215 -10 CURVE"
+"314 365 LINE",
+"333 128 OFFCURVE",
+"404 0 OFFCURVE",
+"569 -9 CURVE",
+"598 63 LINE",
+"531 64 OFFCURVE",
+"481 93 OFFCURVE",
+"451 137 CURVE SMOOTH",
+"381 240 OFFCURVE",
+"373 411 OFFCURVE",
+"366 556 CURVE",
+"280 522 LINE",
+"274 483 OFFCURVE",
+"259 301 OFFCURVE",
+"193 179 CURVE SMOOTH",
+"159 116 OFFCURVE",
+"110 72 OFFCURVE",
+"29 65 CURVE",
+"11 -3 LINE",
+"211 1 OFFCURVE",
+"284 172 OFFCURVE",
+"310 365 CURVE"
 );
 }
 );
-width = 659;
+width = 623;
 }
 );
 unicode = 1048;
@@ -4275,6 +4301,176 @@ width = 594;
 );
 note = uni25CC;
 unicode = 25CC;
+},
+{
+color = 1;
+glyphname = uni1042.alt;
+lastChange = "2024-08-09 11:02:14 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"448 -293 OFFCURVE",
+"550 -162 OFFCURVE",
+"550 62 CURVE SMOOTH",
+"550 209 OFFCURVE",
+"547 413 OFFCURVE",
+"540 546 CURVE",
+"454 536 LINE",
+"463 406 OFFCURVE",
+"464 182 OFFCURVE",
+"464 55 CURVE SMOOTH",
+"464 -168 OFFCURVE",
+"390 -237 OFFCURVE",
+"272 -237 CURVE SMOOTH",
+"167 -237 OFFCURVE",
+"102 -145 OFFCURVE",
+"83 -88 CURVE",
+"4 -123 LINE",
+"52 -213 OFFCURVE",
+"145 -293 OFFCURVE",
+"257 -293 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"448 -293 OFFCURVE",
+"550 -162 OFFCURVE",
+"550 62 CURVE SMOOTH",
+"550 209 OFFCURVE",
+"547 413 OFFCURVE",
+"540 546 CURVE",
+"454 536 LINE",
+"463 406 OFFCURVE",
+"464 182 OFFCURVE",
+"464 55 CURVE SMOOTH",
+"464 -168 OFFCURVE",
+"390 -237 OFFCURVE",
+"272 -237 CURVE SMOOTH",
+"167 -237 OFFCURVE",
+"102 -145 OFFCURVE",
+"83 -88 CURVE",
+"4 -123 LINE",
+"52 -213 OFFCURVE",
+"145 -293 OFFCURVE",
+"257 -293 CURVE SMOOTH"
+);
+}
+);
+width = 599;
+}
+);
+},
+{
+color = 1;
+glyphname = uni1048.alt;
+lastChange = "2024-08-09 11:02:14 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"289 50 OFFCURVE",
+"346 147 OFFCURVE",
+"346 247 CURVE SMOOTH",
+"346 329 OFFCURVE",
+"291 438 OFFCURVE",
+"218 492 CURVE",
+"170 463 LINE",
+"221 417 OFFCURVE",
+"260 352 OFFCURVE",
+"260 233 CURVE SMOOTH",
+"260 170 OFFCURVE",
+"244 108 OFFCURVE",
+"211 63 CURVE",
+"170 89 OFFCURVE",
+"130 169 OFFCURVE",
+"130 283 CURVE SMOOTH",
+"130 394 OFFCURVE",
+"198 490 OFFCURVE",
+"318 490 CURVE SMOOTH",
+"440 490 OFFCURVE",
+"529 395 OFFCURVE",
+"529 252 CURVE SMOOTH",
+"529 153 OFFCURVE",
+"476 69 OFFCURVE",
+"410 34 CURVE",
+"434 -10 LINE",
+"538 42 OFFCURVE",
+"615 152 OFFCURVE",
+"615 269 CURVE SMOOTH",
+"615 396 OFFCURVE",
+"520 546 OFFCURVE",
+"332 546 CURVE SMOOTH",
+"146 546 OFFCURVE",
+"44 400 OFFCURVE",
+"44 264 CURVE SMOOTH",
+"44 155 OFFCURVE",
+"107 28 OFFCURVE",
+"215 -10 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"289 50 OFFCURVE",
+"346 147 OFFCURVE",
+"346 247 CURVE SMOOTH",
+"346 329 OFFCURVE",
+"291 438 OFFCURVE",
+"218 492 CURVE",
+"170 463 LINE",
+"221 417 OFFCURVE",
+"260 352 OFFCURVE",
+"260 233 CURVE SMOOTH",
+"260 170 OFFCURVE",
+"244 108 OFFCURVE",
+"211 63 CURVE",
+"170 89 OFFCURVE",
+"130 169 OFFCURVE",
+"130 283 CURVE SMOOTH",
+"130 394 OFFCURVE",
+"198 490 OFFCURVE",
+"318 490 CURVE SMOOTH",
+"440 490 OFFCURVE",
+"529 395 OFFCURVE",
+"529 252 CURVE SMOOTH",
+"529 153 OFFCURVE",
+"476 69 OFFCURVE",
+"410 34 CURVE",
+"434 -10 LINE",
+"538 42 OFFCURVE",
+"615 152 OFFCURVE",
+"615 269 CURVE SMOOTH",
+"615 396 OFFCURVE",
+"520 546 OFFCURVE",
+"332 546 CURVE SMOOTH",
+"146 546 OFFCURVE",
+"44 400 OFFCURVE",
+"44 264 CURVE SMOOTH",
+"44 155 OFFCURVE",
+"107 28 OFFCURVE",
+"215 -10 CURVE"
+);
+}
+);
+width = 659;
+}
+);
 }
 );
 instances = (


### PR DESCRIPTION
Updates to the following:
U+1042 —MYANMAR DIGIT TWO (for Tai-le) 
U+1048 — MYANMAR DIGIT EIGHT (for Tai-le)

Researched leads me to believe **MYANMAR DIGIT TWO (U+1042)** descends to a similar length below as the baseline as **MYANMAR DIGIT THREE** (U+ 1043) and **FOUR (U+1044)**. There is little to no Tai-le font files to see how others have designed **DIGIT TWO**.

![Screenshot 2024-09-05 at 6 51 37 PM](https://github.com/user-attachments/assets/7915b527-d789-4977-a795-300b74292b25)

The previous designs for U+1042  and U+1048 have been left within the glyph-set and renamed 'XX.alt' incase they are required.
